### PR TITLE
feat(static-route): manage translated routes

### DIFF
--- a/Service/Tools.php
+++ b/Service/Tools.php
@@ -32,6 +32,7 @@ use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 // TODO split this in several single purposes classes (SOLID principles)
 class Tools
@@ -292,10 +293,17 @@ class Tools
                 $seoTags->setRoute($entityOrRequest->get('_route'));
 
                 // TODO ensure or use route parameters ?
-                $seoTags->setCanonicalUrl($this->router->generate(
-                    $entityOrRequest->get('_route'),
-                    $entityOrRequest->get('_route_params'),
-                    Router::ABSOLUTE_URL));
+                try {
+                    $this->languageSwithHelper->getTranslatedUrl(
+                        $entityOrRequest->get('_route'),
+                        $entityOrRequest->get('_route_params')
+                    );
+                } catch(RouteNotFoundException $e) {
+                    $seoTags->setCanonicalUrl($this->router->generate(
+                        $entityOrRequest->get('_route'),
+                        $entityOrRequest->get('_route_params'),
+                        Router::ABSOLUTE_URL));
+                }
 
                 // Open Graph
                 $openGraph->setTitle($seoTags->getTitle());

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "symfony/orm-pack": "^1.0",
     "symfony/validator": "^4.2",
     "knplabs/doctrine-behaviors": "^2.0",
-    "doctrine/annotations": "^1.8"
+    "doctrine/annotations": "^1.8",
+    "lch/translate-bundle": "^0.5.3"
   },
   "require-dev": {
     "doctrine/doctrine-bundle": "^1.3",


### PR DESCRIPTION
try to generate a translated route before default one in order to manage routes from TranslateBundle

Example of a translated route : 

```php
/**
 * @Route(
 *     path={
 *     "fr": "/constructeurs",
 *     "en": "/manufacturers",
 *     "es": "/fabricantes"
 *  },
 *     methods={"GET"},
 *     name="manufacturer_list"
 * )
 */
```

lch_seo configuration package : 

```yaml
lch_seo:
  fr:
    specific:
      ...
      manufacturer_list:
        tags:
          title: "blablou title"
          description: "bliblo description"
        sitemap:
          loc: /constructeurs
          priority: 1.0
```

An error occured while SeoBundle generate this route because `manufacturer_list` does not exists. The correct route was `manufacturer_list.fr` | `manufacturer_list.en` | ...